### PR TITLE
Remove text from artikel/*.html

### DIFF
--- a/artikel/fedora-gnome-tutup-aplikasi.html
+++ b/artikel/fedora-gnome-tutup-aplikasi.html
@@ -10,7 +10,7 @@
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/favicon.ico" sizes="any" />
   <link rel="icon" type="image/svg+xml" href="https://frijal.github.io/assets/favicon.svg" />
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png" />
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png" />
   <meta name="theme-color" content="#06b6d4" />
 
   <!-- CSS ringkas -->

--- a/artikel/hijab-berkeadaban.html
+++ b/artikel/hijab-berkeadaban.html
@@ -11,7 +11,7 @@
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/favicon.ico" sizes="any" />
   <link rel="icon" type="image/svg+xml" href="https://frijal.github.io/assets/favicon.svg" />
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png" />
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png" />
   <meta name="theme-color" content="#7c3aed" />
 
   <!-- Open Graph -->

--- a/artikel/jagung-godog-gerimis.html
+++ b/artikel/jagung-godog-gerimis.html
@@ -11,7 +11,7 @@
     <!-- Favicon & Tema -->
     <link rel="icon" href="https://frijal.github.io/favicon.ico" sizes="any" />
     <link rel="icon" type="image/svg+xml" href="https://frijal.github.io/assets/favicon.svg" />
-    <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png" />
     <meta name="theme-color" content="#f59e0b" />
 
     <!-- Open Graph & Twitter Card -->

--- a/artikel/maulid-kajian-lengkap.html
+++ b/artikel/maulid-kajian-lengkap.html
@@ -10,7 +10,7 @@
 
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/assets/favicon.png" type="image/png">
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png">
   <meta name="theme-color" content="#06b6d4">
 
   <!-- Open Graph -->

--- a/artikel/maulid-nabi.html
+++ b/artikel/maulid-nabi.html
@@ -10,7 +10,7 @@
 
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/assets/favicon.png" type="image/png" />
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png" />
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png" />
   <meta name="theme-color" content="#0ea5e9" />
 
   <!-- Open Graph -->

--- a/artikel/maulid-outline-slides.html
+++ b/artikel/maulid-outline-slides.html
@@ -10,7 +10,7 @@
 
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/assets/favicon.png" type="image/png">
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png">
   <meta name="theme-color" content="#2563eb">
 
   <!-- Open Graph -->

--- a/artikel/maulid-perbandingan.html
+++ b/artikel/maulid-perbandingan.html
@@ -10,7 +10,7 @@
 
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/assets/favicon.png" type="image/png">
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png">
   <meta name="theme-color" content="#8b5cf6">
 
   <!-- Open Graph -->

--- a/artikel/maulid-ringkas.html
+++ b/artikel/maulid-ringkas.html
@@ -10,7 +10,7 @@
 
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/assets/favicon.png" type="image/png">
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png">
   <meta name="theme-color" content="#14b8a6">
 
   <!-- Open Graph -->

--- a/artikel/maulid-slides.html
+++ b/artikel/maulid-slides.html
@@ -10,7 +10,7 @@
 
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/assets/favicon.png" type="image/png">
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png">
   <meta name="theme-color" content="#dc5a00">
 
   <!-- Open Graph -->

--- a/artikel/maulid-timeline.html
+++ b/artikel/maulid-timeline.html
@@ -10,7 +10,7 @@
 
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/assets/favicon.png" type="image/png">
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png">
   <meta name="theme-color" content="#10b981">
 
   <!-- Open Graph -->

--- a/artikel/oss-di-sekolah.html
+++ b/artikel/oss-di-sekolah.html
@@ -11,7 +11,7 @@
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/favicon.ico" sizes="any" />
   <link rel="icon" type="image/svg+xml" href="https://frijal.github.io/assets/favicon.svg" />
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png" />
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png" />
   <meta name="theme-color" content="#2563eb" />
 
   <!-- Open Graph -->

--- a/artikel/sebarubuntu-2014.html
+++ b/artikel/sebarubuntu-2014.html
@@ -17,7 +17,7 @@
   <!-- Icons / Favicon -->
   <link rel="icon" href="https://frijal.github.io/favicon.png" sizes="32x32" />
   <link rel="icon" href="https://frijal.github.io/favicon.png" sizes="192x192" />
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png" />
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png" />
   <link rel="manifest" href="https://frijal.github.io/manifest.webmanifest" />
 
   <!-- Open Graph -->

--- a/artikel/ubuntu-1010-maverick.html
+++ b/artikel/ubuntu-1010-maverick.html
@@ -9,7 +9,7 @@
 
     <link rel="icon" href="https://frijal.github.io/favicon.ico" sizes="any" />
     <link rel="icon" type="image/svg+xml" href="https://frijal.github.io/assets/favicon.svg" />
-    <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png" />
     <meta name="theme-color" content="#E95420" />
 
     <meta property="og:type" content="article" />

--- a/artikel/ubuntu-di-bontang.html
+++ b/artikel/ubuntu-di-bontang.html
@@ -11,7 +11,7 @@
   <!-- Favicon -->
   <link rel="icon" href="https://frijal.github.io/favicon.ico" sizes="any" />
   <link rel="icon" type="image/svg+xml" href="https://frijal.github.io/assets/favicon.svg" />
-  <link rel="apple-touch-icon" href="https://frijal.github.io/assets/apple-touch-icon.png" />
+  <link rel="apple-touch-icon" href="https://frijal.github.io/icon.png" />
   <meta name="theme-color" content="#0ea5e9" />
 
   <!-- Open Graph -->


### PR DESCRIPTION
This PR removes the following text from all HTML files in `artikel/`:

```
assets/apple-touch-
```

✅ Auto-generated by GitHub Actions