### PR TITLE
Remove text from artikel/*.html

### DIFF
--- a/artikel/fedora15-networkmanager-fix.html
+++ b/artikel/fedora15-networkmanager-fix.html
@@ -59,7 +59,7 @@
       "name": "Frijal",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://frijal.github.io/assets/logo-512.png"
+        "url": "https://frijal.github.io/assets/logo.png"
       }
     },
     "datePublished": "2011-05-31T09:00:00+07:00",

--- a/artikel/hapus-os-ilegal-aman.html
+++ b/artikel/hapus-os-ilegal-aman.html
@@ -59,7 +59,7 @@
       "name": "Frijal",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://frijal.github.io/assets/logo-512.png"
+        "url": "https://frijal.github.io/assets/logo.png"
       }
     },
     "datePublished": "2014-02-10T09:00:00+07:00",

--- a/artikel/sebarubuntu-2014.html
+++ b/artikel/sebarubuntu-2014.html
@@ -59,7 +59,7 @@
       "name": "Frijal",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://frijal.github.io/assets/logo-512.png"
+        "url": "https://frijal.github.io/assets/logo.png"
       }
     },
     "datePublished": "2014-02-01T00:00:00+07:00",


### PR DESCRIPTION
This PR removes the following text from all HTML files in `artikel/`:

```
-512
```

✅ Auto-generated by GitHub Actions