### PR TITLE
Remove text from ext/*.html

### DIFF
--- a/ext/adab-berdoa.html
+++ b/ext/adab-berdoa.html
@@ -231,7 +231,7 @@
     #related-posts-list li a{
       display:block; padding:8px 6px; color:#dbeafe; text-decoration:none; border-radius:8px;
     }
-    #related-posts-list li a:hover{ background:rgba(255,255,255,.06); }
+    
   </style>
 </head>
 <body>

--- a/ext/queen-annes-revenge.html
+++ b/ext/queen-annes-revenge.html
@@ -353,7 +353,7 @@
       color:#dbeafe; text-decoration:none;
       border-radius:8px;
     }
-    #related-posts-list li a:hover{ background:rgba(255,255,255,.06); }
+    
   </style>
 </head>
 <body>


### PR DESCRIPTION
This PR removes the following text from all HTML files in `ext/`:

```
#related-posts-list li a:hover{ background:rgba(255,255,255,.06); }
```

✅ Auto-generated by GitHub Actions