### PR TITLE
Remove text from artikel/*.html

### DIFF
--- a/artikel/adab-berdoa.html
+++ b/artikel/adab-berdoa.html
@@ -228,7 +228,7 @@
     #related-posts-container.open{ display:block; }
     #related-posts-list{ list-style:none; margin:0; padding:0; }
     #related-posts-list li a{
-      display:block; padding:8px 6px; color:#dbeafe; text-decoration:none; border-radius:8px;
+      
     }
     #related-posts-list li a:hover{ background:rgba(255,255,255,.06); }
   </style>


### PR DESCRIPTION
This PR removes the following text from all HTML files in `artikel/`:

```
display:block; padding:8px 6px; color:#dbeafe; text-decoration:none; border-radius:8px;
```

✅ Auto-generated by GitHub Actions