### PR TITLE
Remove text from artikel/*.html

### DIFF
--- a/artikel/adab-berdoa.html
+++ b/artikel/adab-berdoa.html
@@ -227,7 +227,7 @@
     }
     #related-posts-container.open{ display:block; }
     #related-posts-list{ list-style:none; margin:0; padding:0; }
-    #related-posts-list li a{
+    
       display:block; padding:8px 6px; color:#dbeafe; text-decoration:none; border-radius:8px;
     }
     #related-posts-list li a:hover{ background:rgba(255,255,255,.06); }

--- a/artikel/apt-debian-history.html
+++ b/artikel/apt-debian-history.html
@@ -338,7 +338,7 @@ sudo apt history-list | grep curl</code></pre>
     }
     #related-posts-container.open{display:block}
     #related-posts-list{list-style:none;margin:0;padding:0;display:grid;gap:.4rem}
-    #related-posts-list li a{display:block;padding:.45rem .6rem;border-radius:8px;background:#0b1416;color:#d5e7e7}
+    display:block;padding:.45rem .6rem;border-radius:8px;background:#0b1416;color:#d5e7e7}
     #related-posts-list li a:hover{background:#0f1b1d}
   </style>
 

--- a/artikel/gnome-49.html
+++ b/artikel/gnome-49.html
@@ -331,7 +331,7 @@
     }
     #related-posts-container.open{display:block}
     #related-posts-list{list-style:none;margin:0;padding:0;display:grid;gap:.4rem}
-    #related-posts-list li a{display:block;padding:.45rem .6rem;border-radius:8px;background:#0f172a;color:#cbd5e1}
+    display:block;padding:.45rem .6rem;border-radius:8px;background:#0f172a;color:#cbd5e1}
     #related-posts-list li a:hover{background:#121e33}
   </style>
 

--- a/artikel/linux-mint-22-2-upgrade-step.html
+++ b/artikel/linux-mint-22-2-upgrade-step.html
@@ -377,7 +377,7 @@
     }
     #related-posts-container.open{display:block}
     #related-posts-list{list-style:none;margin:0;padding:0;display:grid;gap:.4rem}
-    #related-posts-list li a{display:block;padding:.45rem .6rem;border-radius:8px;background:#0e1a14;color:#d7f1e3}
+    display:block;padding:.45rem .6rem;border-radius:8px;background:#0e1a14;color:#d7f1e3}
     #related-posts-list li a:hover{background:#10231a}
   </style>
 

--- a/artikel/penaklukan-mesir.html
+++ b/artikel/penaklukan-mesir.html
@@ -240,7 +240,7 @@ footer.site{
 }
 #related-posts-container.open{ display:block; }
 #related-posts-list{ list-style:none; margin:0; padding:0; }
-#related-posts-list li a{
+
   display:block; padding:8px 6px; color:#eaf6ff; text-decoration:none; border-radius:8px;
 }
 #related-posts-list li a:hover{ background:rgba(255,255,255,.10); }

--- a/artikel/queen-annes-revenge.html
+++ b/artikel/queen-annes-revenge.html
@@ -348,7 +348,7 @@
     #related-posts-list{
       list-style:none; margin:0; padding:0;
     }
-    #related-posts-list li a{
+    
       display:block; padding:8px 6px;
       color:#dbeafe; text-decoration:none;
       border-radius:8px;

--- a/artikel/thunderbird-exchange-144.html
+++ b/artikel/thunderbird-exchange-144.html
@@ -336,7 +336,7 @@
     }
     #related-posts-container.open{display:block}
     #related-posts-list{list-style:none;margin:0;padding:0;display:grid;gap:.4rem}
-    #related-posts-list li a{display:block;padding:.45rem .6rem;border-radius:8px;background:#0e0f19;color:#dfe2ff}
+    display:block;padding:.45rem .6rem;border-radius:8px;background:#0e0f19;color:#dfe2ff}
     #related-posts-list li a:hover{background:#121327}
   </style>
 

--- a/artikel/ubuntu-25-10-beta.html
+++ b/artikel/ubuntu-25-10-beta.html
@@ -356,7 +356,7 @@
     }
     #related-posts-container.open{display:block}
     #related-posts-list{list-style:none;margin:0;padding:0;display:grid;gap:.4rem}
-    #related-posts-list li a{display:block;padding:.45rem .6rem;border-radius:8px;background:#1b1a17;color:#e9e9e4}
+    display:block;padding:.45rem .6rem;border-radius:8px;background:#1b1a17;color:#e9e9e4}
     #related-posts-list li a:hover{background:#211f1b}
   </style>
 

--- a/artikel/zorin-os-18-beta.html
+++ b/artikel/zorin-os-18-beta.html
@@ -373,7 +373,7 @@
     }
     #related-posts-container.open{display:block}
     #related-posts-list{list-style:none;margin:0;padding:0;display:grid;gap:.4rem}
-    #related-posts-list li a{display:block;padding:.45rem .6rem;border-radius:8px;background:#0b1020;color:#dbe6ff}
+    display:block;padding:.45rem .6rem;border-radius:8px;background:#0b1020;color:#dbe6ff}
     #related-posts-list li a:hover{background:#0f1630}
   </style>
 


### PR DESCRIPTION
This PR removes the following text from all HTML files in `artikel/`:

```
#related-posts-list li a{
```

✅ Auto-generated by GitHub Actions