### PR TITLE
Remove text from artikel/*.html

### DIFF
--- a/artikel/kompres-pdf-ghostscript.html
+++ b/artikel/kompres-pdf-ghostscript.html
@@ -15,14 +15,14 @@
   <meta property="og:title" content="Kompres PDF Hasil Scan dengan Ghostscript di Linux: Cepat, Mudah, Efektif" />
   <meta property="og:description" content="Panduan singkat mengecilkan ukuran PDF hasil scan dengan Ghostscript. Pilih kualitas sesuai kebutuhan, kirim email lebih ringan." />
   <meta property="og:url" content="https://frijal.github.io/artikel/kompres-pdf-ghostscript.html" />
-  <meta property="og:image" content="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhHzahydQn3VjRRz_RA6o7-ebiPiZr0VvcwxOplhpq6KcPwAQ0XvBq19SoIapkr0Jx0TTBa79YuG7XcjEeVlAMMY2o5Q1xF0O8U2kaClVMjL_c8HFbA_P_1jiWh4aR8xCPAQ39hOYCPUu-35G01-Y67AJJ6GDKSQiGdqmTbs0T9G0sVBEmR3T5nAJgBepE/s1600/photo-1510936111840-65e151ad71bb.jpg?w=1200&q=80&auto=format&fit=crop" />
+  <meta property="og:image" content="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhHzahydQn3VjRRz_RA6o7-ebiPiZr0VvcwxOplhpq6KcPwAQ0XvBq19SoIapkr0Jx0TTBa79YuG7XcjEeVlAMMY2o5Q1xF0O8U2kaClVMjL_c8HFbA_P_1jiWh4aR8xCPAQ39hOYCPUu-35G01-Y67AJJ6GDKSQiGdqmTbs0T9G0sVBEmR3T5nAJgBepE/s1600/photo-1510936111840-65e151ad71bb.jpg" />
   <meta property="og:locale" content="id_ID" />
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Kompres PDF Hasil Scan dengan Ghostscript di Linux: Cepat, Mudah, Efektif" />
   <meta name="twitter:description" content="Panduan singkat mengecilkan ukuran PDF hasil scan dengan Ghostscript. Pilih kualitas sesuai kebutuhan, kirim email lebih ringan." />
-  <meta name="twitter:image" content="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhHzahydQn3VjRRz_RA6o7-ebiPiZr0VvcwxOplhpq6KcPwAQ0XvBq19SoIapkr0Jx0TTBa79YuG7XcjEeVlAMMY2o5Q1xF0O8U2kaClVMjL_c8HFbA_P_1jiWh4aR8xCPAQ39hOYCPUu-35G01-Y67AJJ6GDKSQiGdqmTbs0T9G0sVBEmR3T5nAJgBepE/s1600/photo-1510936111840-65e151ad71bb.jpg?w=1200&q=80&auto=format&fit=crop" />
+  <meta name="twitter:image" content="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhHzahydQn3VjRRz_RA6o7-ebiPiZr0VvcwxOplhpq6KcPwAQ0XvBq19SoIapkr0Jx0TTBa79YuG7XcjEeVlAMMY2o5Q1xF0O8U2kaClVMjL_c8HFbA_P_1jiWh4aR8xCPAQ39hOYCPUu-35G01-Y67AJJ6GDKSQiGdqmTbs0T9G0sVBEmR3T5nAJgBepE/s1600/photo-1510936111840-65e151ad71bb.jpg" />
 
   <!-- Prism (syntax highlight) -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" integrity="sha512-Mq9P6YjYsm2JMV8Q+r5e5s6NY68zJ0R3z4dv5/1w5z/3H6wRM9mC4u4Gz0V7XvO6ilH2h1eQ8q5Q8gW2+oE5ug==" crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -176,7 +176,7 @@
     "inLanguage":"id",
     "author":{"@type":"Person","name":"Kontributor"},
     "publisher":{"@type":"Organization","name":"frijal.github.io","logo":{"@type":"ImageObject","url":"https://frijal.github.io/favicon.ico"}},
-    "image":"https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhHzahydQn3VjRRz_RA6o7-ebiPiZr0VvcwxOplhpq6KcPwAQ0XvBq19SoIapkr0Jx0TTBa79YuG7XcjEeVlAMMY2o5Q1xF0O8U2kaClVMjL_c8HFbA_P_1jiWh4aR8xCPAQ39hOYCPUu-35G01-Y67AJJ6GDKSQiGdqmTbs0T9G0sVBEmR3T5nAJgBepE/s1600/photo-1510936111840-65e151ad71bb.jpg?w=1200&q=80&auto=format&fit=crop",
+    "image":"https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhHzahydQn3VjRRz_RA6o7-ebiPiZr0VvcwxOplhpq6KcPwAQ0XvBq19SoIapkr0Jx0TTBa79YuG7XcjEeVlAMMY2o5Q1xF0O8U2kaClVMjL_c8HFbA_P_1jiWh4aR8xCPAQ39hOYCPUu-35G01-Y67AJJ6GDKSQiGdqmTbs0T9G0sVBEmR3T5nAJgBepE/s1600/photo-1510936111840-65e151ad71bb.jpg",
     "mainEntityOfPage":{"@type":"WebPage","@id":"https://frijal.github.io/artikel/kompres-pdf-ghostscript.html"},
     "datePublished":"2025-09-17",
     "dateModified":"2025-09-17"


### PR DESCRIPTION
This PR removes the following text from all HTML files in `artikel/`:

```
?w=1200&q=80&auto=format&fit=crop
```

✅ Auto-generated by GitHub Actions