### PR TITLE
Remove text from artikel/*.html

### DIFF
--- a/artikel/pasang-ubuntu-aspire-2930z.html
+++ b/artikel/pasang-ubuntu-aspire-2930z.html
@@ -60,7 +60,7 @@
       "name": "Frijal",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://frijal.github.io/thumbnail.jpg"
+        "url": ""
       }
     },
     "datePublished": "2010-01-20T17:00:00+07:00",


### PR DESCRIPTION
This PR removes the following text from all HTML files in `artikel/`:

```
https://frijal.github.io/thumbnail.jpg
```

✅ Auto-generated by GitHub Actions