### PR TITLE
Remove text from mini/*.html

### DIFF
--- a/mini/adaro-perusahaan-tambang-batu-bara.html
+++ b/mini/adaro-perusahaan-tambang-batu-bara.html
@@ -52,7 +52,7 @@
                 </div>
             </div>
             <aside class="hero-thumb">
-                <img src="https://frijal.github.io/thumbnail.jpg" alt="Thumbnail Adaro" id="header-thumb" width="320" height="200" loading="eager">
+                <img src="https://frijal.github.io/" alt="Thumbnail Adaro" id="header-thumb" width="320" height="200" loading="eager">
             </aside>
         </header>
         


### PR DESCRIPTION
This PR removes the following text from all HTML files in `mini/`:

```
thumbnail.jpg
```

✅ Auto-generated by GitHub Actions